### PR TITLE
🔧 build(mvn): Fix project.version in pom.xml

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -78,7 +78,7 @@
     </dependencies>
 
     <build>
-        <finalName>${project.groupId}-${project.artifactId}-kc-${keycloak-version}-b-${version}</finalName>
+        <finalName>${project.groupId}-${project.artifactId}-kc-${keycloak-version}-b-${project.version}</finalName>
 
         <plugins>
             <plugin>


### PR DESCRIPTION
The expression ${version} is deprecated. Please use ${project.version} instead.