### PR TITLE
🐳 chore(release): Release-drafter config trigger ci properly v12

### DIFF
--- a/.github/workflows/release-drafter.yml
+++ b/.github/workflows/release-drafter.yml
@@ -3,8 +3,10 @@ name: Release Drafter
 on:
   push:
     branches: [main]
+  # pull_request event is required only for autolabeler
   pull_request:
-    types: [closed]
+    # Only following types are handled by the action, but one can default to all as well
+    types: [opened, reopened, synchronize]
   workflow_dispatch:
 permissions: read-all
 jobs:


### PR DESCRIPTION
Properly trigger ci of release-drafter for auto labeling