### PR TITLE
🦄 refactor(config): Remove unused import from config

### DIFF
--- a/src/main/java/idnord/keycloak/config/LimitResendEmailConfiguration.java
+++ b/src/main/java/idnord/keycloak/config/LimitResendEmailConfiguration.java
@@ -1,10 +1,7 @@
 package idnord.keycloak.config;
 
-import lombok.extern.slf4j.Slf4j;
-
 import java.util.Optional;
 
-@Slf4j
 public class LimitResendEmailConfiguration {
 
     public static final int LIMIT_RESEND_EMAIL_MAX_RETRIES;


### PR DESCRIPTION
Config class initializes too early to pring log so we moved logging out from the Config class but we forgot to remove unused import of slf4j