### PR TITLE
🐎 ci(log): Add log for debug host in test ci

### DIFF
--- a/src/test/java/idnord/keycloak/utilities/UserBehaviorTestUtils.java
+++ b/src/test/java/idnord/keycloak/utilities/UserBehaviorTestUtils.java
@@ -42,6 +42,7 @@ public class UserBehaviorTestUtils {
 
         // docker localhost is different on docker desktop and github ci
         try {
+            System.out.println("Trying to use host=" + host);
             driver.get("http://" + host + ":8080/realms/master/account");
         } catch (Exception e) {
             host = "host.docker.internal";


### PR DESCRIPTION
GIthub ci fails because of using desktop docker host so we need to add additional log to confirm it uses correct host in ci