### PR TITLE
✨ feat(page): Show error pages with friendly messages if limit has be…

### DIFF
--- a/src/main/java/idnord/keycloak/authenticator/LimitResendEmailAuthenticator.java
+++ b/src/main/java/idnord/keycloak/authenticator/LimitResendEmailAuthenticator.java
@@ -1,13 +1,14 @@
 package idnord.keycloak.authenticator;
 
 import idnord.keycloak.LimitResendEmailCore;
+import jakarta.ws.rs.core.Response;
 import lombok.extern.slf4j.Slf4j;
 import org.keycloak.authentication.AuthenticationFlowContext;
-import org.keycloak.authentication.AuthenticationFlowError;
 import org.keycloak.authentication.Authenticator;
 import org.keycloak.models.KeycloakSession;
 import org.keycloak.models.RealmModel;
 import org.keycloak.models.UserModel;
+import org.keycloak.services.messages.Messages;
 
 import static idnord.keycloak.config.LimitResendEmailConfiguration.LIMIT_RESEND_EMAIL_MAX_RETRIES;
 import static idnord.keycloak.config.LimitResendEmailConfiguration.LIMIT_RESEND_EMAIL_RETRY_BLOCK_DURATION_IN_SEC;
@@ -22,8 +23,13 @@ public class LimitResendEmailAuthenticator implements Authenticator {
         if (LimitResendEmailCore.isLimitResendEmailReached(user, LIMIT_RESEND_EMAIL_MAX_RETRIES, LIMIT_RESEND_EMAIL_RETRY_BLOCK_DURATION_IN_SEC)) {
             log.info("Email sending limited for username={}, clientId={}, IP={}.",
                     user.getUsername(), context.getAuthenticationSession().getClient().getClientId(), context.getSession().getContext().getConnection().getRemoteAddr());
-            context.failure(AuthenticationFlowError.USER_TEMPORARILY_DISABLED);
-            // @TODO a page with custom message
+
+            context.challenge(
+                    context.form()
+                            .setError(user.isEmailVerified() ? Messages.EMAIL_SENT_ERROR : Messages.VERIFY_EMAIL)
+                            .createErrorPage(Response.Status.TOO_MANY_REQUESTS)
+            );
+
         } else {
             context.success();
         }

--- a/src/test/java/idnord/keycloak/functionality/EmailSendingTest.java
+++ b/src/test/java/idnord/keycloak/functionality/EmailSendingTest.java
@@ -137,7 +137,7 @@ public class EmailSendingTest {
         }
         int emailCountAfterMaxAttempts = ms.getEmailCount().size();
         try {
-            assertTrue(ub.clickResend("Failed to send email", "/login-actions/required-action?execution=VERIFY_EMAIL"));
+            assertTrue(ub.clickResend("We are sorry", "/login-actions/required-action?execution=VERIFY_EMAIL"));
 
             int emailCountFromAttribute = Integer.parseInt(Optional.of(kc.getAttribute(userId, "LimitResendEmailCount")).orElse("0"));
             System.out.println("emailCountFromAttribute LimitResendEmailCount=" + emailCountFromAttribute);


### PR DESCRIPTION
…en reached

Before email verified we show "You need to verify your email address to activate your account." After email verified and user tries many forgot password attempts we show "Failed to send email, please try again later."

BREAKING CHANGE: ready for the first LTS version