### PR TITLE
🎈 perf(core): last time attr type consistency

### DIFF
--- a/src/main/java/idnord/keycloak/LimitResendEmailCore.java
+++ b/src/main/java/idnord/keycloak/LimitResendEmailCore.java
@@ -1,5 +1,6 @@
 package idnord.keycloak;
 
+import org.keycloak.common.util.Time;
 import org.keycloak.models.UserModel;
 
 public class LimitResendEmailCore {
@@ -10,7 +11,7 @@ public class LimitResendEmailCore {
     public static boolean isLimitResendEmailReached(UserModel user, final int LIMIT_RESEND_EMAIL_MAX_RETRIES, final int LIMIT_RESEND_EMAIL_BLOCK_DURATION_SECONDS) {
 
         int count = 0;
-        long lastEmailSentTime = 0;
+        int lastEmailSentTime = 0;
 
         try {
             String countAttr = user.getFirstAttribute(LimitResendEmailCore.ATTR_FOR_LIMIT_RESEND_EMAIL_COUNT);
@@ -23,7 +24,7 @@ public class LimitResendEmailCore {
         try {
             String lastTimeAttr = user.getFirstAttribute(LimitResendEmailCore.ATTR_FOR_LIMIT_RESEND_EMAIL_LAST_TIME);
             if (lastTimeAttr != null) {
-                lastEmailSentTime = Long.parseLong(lastTimeAttr);
+                lastEmailSentTime = Integer.parseInt(lastTimeAttr);
             }
         } catch (Exception ignored) {
         }
@@ -32,7 +33,7 @@ public class LimitResendEmailCore {
             // send emails immediately until MAX_RETRIES, then only one email after each BLOCK_DURATION is allowed (see reset logic in listener)
             return false;
         } else {
-            long nowTimeInSeconds = System.currentTimeMillis() / 1000;
+            int nowTimeInSeconds = Time.currentTime();
             // If last email was more than DURATION seconds ago allow sending email
             if (nowTimeInSeconds - lastEmailSentTime > LIMIT_RESEND_EMAIL_BLOCK_DURATION_SECONDS) {
                 return false;


### PR DESCRIPTION
Replaced usage of System.currentTimeMillis() with Time.currentTime() from Keycloak's Time utility. Since we store time using int from `Time.currentTime()` we need to read, parse to int. Also compare read int value with another int retrieved using Time.currentTime() instead of System.currentTimeMillis() for consistency.