### PR TITLE
🐳 chore(release): Don't show automatic changes in Release notes

### DIFF
--- a/.github/release-drafter-config.yml
+++ b/.github/release-drafter-config.yml
@@ -80,6 +80,9 @@ autolabeler:
   - label: dependencies
     title:
       - "/.+\\sto\\sv.+"
+  - label: changelog
+    title:
+      - "/[create-pull-request] automated change/i"
 #replacers:
 #  - search: "/[^:]*(\\w+)(\\(\\w+\\))?!?: /g"
 #    replace: ""


### PR DESCRIPTION
We configure release dragter to ignore automcatic PR

[skip ci]