### PR TITLE
🐳 chore(release): Don't show automatic changes in Release notes v2

### DIFF
--- a/.github/release-drafter-config.yml
+++ b/.github/release-drafter-config.yml
@@ -82,7 +82,7 @@ autolabeler:
       - "/.+\\sto\\sv.+"
   - label: changelog
     title:
-      - "/[create-pull-request] automated change/i"
+      - "/^[create-pull-request].*:/i"
 #replacers:
 #  - search: "/[^:]*(\\w+)(\\(\\w+\\))?!?: /g"
 #    replace: ""


### PR DESCRIPTION
We configure release drafter to ignore automatic PR

[skip ci]