### PR TITLE
fix(tests): bind Keycloak to 0.0.0.0 so Docker containers can reach it

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -26,14 +26,7 @@ jobs:
           cache: maven
 
       - name: Configure Docker networking for tests
-        run: sudo iptables -I INPUT -i docker0 -j ACCEPT || true
+        run: sudo iptables -I INPUT -s 172.16.0.0/12 -j ACCEPT || true
 
       - name: Build with Maven
-        run: |
-          DOCKER_HOST_IP=$(ip -4 addr show docker0 2>/dev/null \
-            | grep -oP '(?<=inet )\d+(\.\d+){3}' | head -1)
-          if [ -n "$DOCKER_HOST_IP" ]; then
-            mvn -B -q clean package -Dtest.host="$DOCKER_HOST_IP"
-          else
-            mvn -B -q clean package
-          fi
+        run: mvn -B --no-transfer-progress package

--- a/src/test/java/org/keycloak/Keycloak.java
+++ b/src/test/java/org/keycloak/Keycloak.java
@@ -307,6 +307,7 @@ public class Keycloak {
             this.addOptionIfNotSet(args, HttpOptions.HTTP_ENABLED, true);
             this.addOptionIfNotSet(args, HttpOptions.HTTP_PORT);
             this.addOptionIfNotSet(args, HttpOptions.HTTPS_PORT);
+            this.addOptionIfNotSet(args, HttpOptions.HTTP_HOST, "0.0.0.0");
             boolean isFipsEnabled = Optional.ofNullable(this.getOptionValue(args, SecurityOptions.FIPS_MODE))
                     .map(FipsMode::valueOfOption)
                     .orElse(FipsMode.DISABLED)


### PR DESCRIPTION
Quarkus TEST mode defaults quarkus.http.host to localhost, overriding Keycloak's kc.http-host default of 0.0.0.0. Chrome inside the Selenium Docker container gets ERR_CONNECTION_REFUSED because nothing listens on the Docker bridge IPs. Explicitly passing --http-host=0.0.0.0 in the embedded Keycloak Builder forces binding to all interfaces.

Also simplify the CI workflow: remove the docker0 IP detection and test.host override (wrong network — Selenium container is on 172.18.x, not 172.17.x), and widen the iptables rule to cover all Docker subnets (172.16.0.0/12) instead of only docker0.